### PR TITLE
DESCW-3096 remove composer version question from checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This works the same as `postProductionChecks` above except it does not run phpun
 
 Typical composer.json for theme / plugin
 
-```
+```JSON
 "require-dev": {
     "bcgov/wordpress-utils": "@dev"
 },
@@ -104,15 +104,15 @@ Typical composer.json for theme / plugin
 
 Change the version of wordpress-utils in composer.json
 
-        ```JSON
-            '"require-dev": {',
-            '...',
-            '"bcgov/wordpress-utils": "2.0"',
-            '...',
-            '}',
-        ```
+```JSON
+    "require-dev": {
+        ...
+        "bcgov/wordpress-utils": "2.5.0",
+        ...
+    }',
+```
 
-> The default is: "@dev" which will use the latest version, but you should specify a version number (currently 2.0) to avoid unexpected changes.
+> The default is: "@dev" which will use the latest version, but you should specify a version number (currently 2.5.0) to avoid unexpected changes.
 
 ### How to downgrade this package to the old version:
 
@@ -120,13 +120,13 @@ _If you would like to suppress the new errors and warnings, (NOT RECOMMENDED), y
 
 Change the version of wordpress-utils in composer.json
 
-        ```JSON
-            '"require-dev": {',
-            '...',
-            '"bcgov/wordpress-utils": "1.1.1"',
-            '...',
-            '}',
-        ```
+```JSON
+    "require-dev": {
+        ...
+        "bcgov/wordpress-utils": "1.1.1",
+        ...
+    },
+```
 
 > DOWNGRADING IS NOT RECOMMENDED: this will prevent the new errors and warnings, and lower the quality of the code.
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Note: The scan requires the `patterns/` folder to be at the root of the theme or
 
 #### Usage
 ```json
-...
-"scripts": {
+{
+    ...
+    "scripts": {
         "scan-wp-patterns": "@php vendor/bin/scan-wp-patterns.php",
+    }
+    ...
 }
-...
 ```
 ## Classes
 
@@ -56,7 +58,7 @@ This works the same as `postProductionChecks` above except it does not run phpun
 
 Typical composer.json for theme / plugin
 
-```JSON
+```json
 "require-dev": {
     "bcgov/wordpress-utils": "@dev"
 },
@@ -104,15 +106,15 @@ Typical composer.json for theme / plugin
 
 Change the version of wordpress-utils in composer.json
 
-```JSON
+```json
     "require-dev": {
         ...
-        "bcgov/wordpress-utils": "2.5.0",
+        "bcgov/wordpress-utils": "2.8.0",
         ...
-    }',
+    },
 ```
 
-> The default is: "@dev" which will use the latest version, but you should specify a version number (currently 2.5.0) to avoid unexpected changes.
+> The default is: "@dev" which will use the latest version, but you should specify a version number (currently 2.8.0) to avoid unexpected changes.
 
 ### How to downgrade this package to the old version:
 
@@ -120,12 +122,12 @@ _If you would like to suppress the new errors and warnings, (NOT RECOMMENDED), y
 
 Change the version of wordpress-utils in composer.json
 
-```JSON
-    "require-dev": {
-        ...
-        "bcgov/wordpress-utils": "1.1.1",
-        ...
-    },
+```json
+"require-dev": {
+    ...
+    "bcgov/wordpress-utils": "1.1.1",
+    ...
+},
 ```
 
 > DOWNGRADING IS NOT RECOMMENDED: this will prevent the new errors and warnings, and lower the quality of the code.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Here are some of the things it scans:
 
 Note: The scan requires the `patterns/` folder to be at the root of the theme or plugin.
 
-#### Usage 
+#### Usage
 ```json
 ...
 "scripts": {
@@ -50,7 +50,7 @@ This is used to create a checklist, which creates a checklist.md in your root of
 
 #### \Bcgov\Script\Checklists::postProductionChecksSkipPhpunit
 
-This works the same as `postProductionChecks` above except it does not run phpunit tests so that the rest of the checklist can pass when phpunit tests cannot be run. This is useful for themes and plugins that use [WordPress' recommended unit test environment](https://make.wordpress.org/cli/handbook/misc/plugin-unit-tests/) as it is not compatible with \Bcgov\Script\Tests. 
+This works the same as `postProductionChecks` above except it does not run phpunit tests so that the rest of the checklist can pass when phpunit tests cannot be run. This is useful for themes and plugins that use [WordPress' recommended unit test environment](https://make.wordpress.org/cli/handbook/misc/plugin-unit-tests/) as it is not compatible with \Bcgov\Script\Tests.
 
 ## Composer.json
 

--- a/src/Checklists.php
+++ b/src/Checklists.php
@@ -103,7 +103,6 @@ class Checklists
                 'no'  => 'no',
             ];
             $confirm       = (object) [
-                'composer'      => $io->select('Is your version in composer.json the correct version? (Default Yes)', $selectChoices, 'yes'),
                 'style'         => $io->select('Is your version in your style.css or plugin file the correct version? (Default Yes)', $selectChoices, 'yes'),
                 'changelog'     => $io->select('Did you update the CHANGELOG.md to include jira tickets? (Default Yes)', $selectChoices, 'yes'),
                 'readme'        => $io->select('Update README.md if applicable? (Default No)', $selectChoices, 'no'),
@@ -128,7 +127,6 @@ class Checklists
             }
             $checklist = array_merge(
                 [
-                    "* [{$confirm->composer}] Updated version in composer.json",
                     "* [{$confirm->style}] Updated version in style.css or plugin file",
                     "* [{$confirm->changelog}] Updated CHANGELOG.md to include jira ticket",
                     "* [{$confirm->readme}] Updated README.md for new functionality",
@@ -178,7 +176,6 @@ class Checklists
     public static function postProductionChecksForCommon(): void
     {
         $checklist = [
-            '[] Updated version in composer.json',
             '[] Updated CHANGELOG.md to include jira ticket',
             '[] Updated README.md for new functionality',
             '[] Verified coding standards (phpcs)',


### PR DESCRIPTION
This pull request removes the checklist item that asks about updating the version in `composer.json` from both the documentation and the automated checklists. This streamlines the release process by no longer requiring confirmation of the `composer.json` version during post-production checks.

Checklist and documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R3): Documented the removal of the checklist item regarding the `composer.json` version.
* [`src/Checklists.php`](diffhunk://#diff-3fd2548f10df4ba710cef6d61176806aba0b37134a381f822a4a7d2ffd45f015L93): Removed prompts and checklist entries for updating the `composer.json` version from `postProductionChecks`, `postProductionChecksForCommon`, and `postProductionChecksForScripts` methods. [[1]](diffhunk://#diff-3fd2548f10df4ba710cef6d61176806aba0b37134a381f822a4a7d2ffd45f015L93) [[2]](diffhunk://#diff-3fd2548f10df4ba710cef6d61176806aba0b37134a381f822a4a7d2ffd45f015L118) [[3]](diffhunk://#diff-3fd2548f10df4ba710cef6d61176806aba0b37134a381f822a4a7d2ffd45f015L168) [[4]](diffhunk://#diff-3fd2548f10df4ba710cef6d61176806aba0b37134a381f822a4a7d2ffd45f015L189)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51): Updated documentation to reflect the removal of the `composer.json` checklist item.