### PR TITLE
Feature/descw 3241 fix exclude pattern

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -30,13 +30,17 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
-			<property name="prefixes" type="array" value="my-plugin"/>
+			<property name="prefixes">
+				<element value="my-plugin"/>
+			</property>
 		</properties>
 	</rule>
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- Value: replace the text domain used. -->
-			<property name="text_domain" type="array" value="my-plugin"/>
+			<property name="text_domain">
+				<element value="my-plugin"/>
+			</property>
 		</properties>
 	</rule>
 	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -27,6 +27,9 @@
 	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="4.6"/>
 	<rule ref="WordPress"/>
+	<!-- Ignore Tab/Space indenting-->
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" ><severity>0</severity></rule>
+	<rule ref="Generic.WhiteSpace.DisallowTabIndent"><type>warning</type><severity>0</severity></rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Change the version of wordpress-utils in composer.json
 ```json
     "require-dev": {
         ...
-        "bcgov/wordpress-utils": "2.8.0",
+        "bcgov/wordpress-utils": "2.8.1",
         ...
     },
 ```

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "scripts": {
 
         "phpcs": [
-            "./vendor/bin/phpcs --config-set --config-set error_severity 1 -i;",
-            "./vendor/bin/phpcs -ps --colors ./ &2>/dev/null;"
+            "./vendor/bin/phpcs --config-set error_severity 1 -i;",
+            "./vendor/bin/phpcs -v -ps --colors ./"
         ],
         "phpcbf": [
             "./vendor/bin/phpcbf -ps --colors ./ &2>/dev/null;"

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
 
         "phpcs": [
             "./vendor/bin/phpcs --config-set error_severity 1 -i;",
-            "./vendor/bin/phpcs -v -ps --colors ./"
+            "./vendor/bin/phpcs -ps --colors;"
         ],
         "phpcbf": [
-            "./vendor/bin/phpcbf -ps --colors ./ &2>/dev/null;"
+            "./vendor/bin/phpcbf -ps --colors;"
         ],
         "test": [
             "./vendor/bin/phpunit"

--- a/wordpress.xml
+++ b/wordpress.xml
@@ -10,19 +10,16 @@
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 
 	<!-- Exclude minified Javascript files. -->
-	<exclude-pattern>*.min.js</exclude-pattern>
 	<exclude-pattern>*.js</exclude-pattern>
-  	<exclude-pattern>/tests/_*</exclude-pattern>
-	<exclude-pattern>/coverage/*</exclude-pattern>
-	<exclude-pattern>/vendor/*</exclude-pattern>
-	<exclude-pattern>/node_modules/*</exclude-pattern>
-	<exclude-pattern>/dist*/*</exclude-pattern>
+	<exclude-pattern>*.min.js</exclude-pattern>
 	<exclude-pattern>*/build/*</exclude-pattern>
-    <exclude-pattern>*Scripts.php</exclude-pattern>
+	<exclude-pattern>*/dist/*</exclude-pattern>
+	<exclude-pattern>*Scripts.php</exclude-pattern>
+	<exclude-pattern>/coverage/*</exclude-pattern>
+	<exclude-pattern>/tests/_*</exclude-pattern>
 
 	<!-- Until a better solution comes to code check blade files. -->
 	<exclude-pattern>*.blade.php</exclude-pattern>
-
 
 	<!-- Include the WordPress-Extra standard. -->
 	<rule ref="WordPress-Extra">
@@ -48,14 +45,14 @@
 	<rule ref="WordPress-Docs"/>
 
 	<!-- Add in some extra rules from other standards. -->
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" ><severity>0</severity></rule>
+	<rule ref="Generic.WhiteSpace.DisallowTabIndent"><type>warning</type><severity>0</severity></rule>
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
 	<rule ref="Generic.Commenting.Todo"/>
-	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" ><severity>0</severity></rule>
 	<rule ref="Universal.Arrays.DisallowShortArraySyntax.Found" ><severity>0</severity></rule>
-    <rule ref="Generic.WhiteSpace.DisallowTabIndent"><type>warning</type><severity>0</severity></rule>
 	<rule ref="Squiz.Commenting.FileComment.Missing"><severity>0</severity></rule>
 	<rule ref="Squiz.Commenting.FileComment.SpacingAfterComment"><severity>0</severity></rule>
-  	<rule ref="WordPress.WP.I18n.TextDomainMismatch"><severity>0</severity></rule>
+	<rule ref="WordPress.WP.I18n.TextDomainMismatch"><severity>0</severity></rule>
 	<rule ref="Universal.WhiteSpace.PrecisionAlignment.Found"><severity>0</severity></rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound"><severity>0</severity></rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound"><severity>0</severity></rule>
@@ -64,22 +61,21 @@
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName"><severity>0</severity></rule>
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase"><severity>0</severity></rule>
 	<rule ref="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase"><severity>warning</severity></rule>
-
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound"><severity>0</severity></rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound"><severity>0</severity></rule>
 	<rule ref="WordPress.NamingConventions.ValidHookName.UseUnderscores"><severity>0</severity></rule>
+
 	<!-- gives warning if there is no domain after __('string', domain) -->
 	<rule ref="WordPress.WP.I18n.MissingArgDomain"><severity>0</severity></rule>
 
 	<!-- gives warning if there isn't a comment after parameter -->
 	<rule ref="Squiz.Commenting.FunctionComment.MissingParamComment"><severity>0</severity></rule>
-	<rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace">
-        <severity>0</severity>
-    </rule>
+	<rule ref="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace"><severity>0</severity></rule>
+
 	<config name="minimum_supported_wp_version" value="5.6"/>
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array">
+			<property name="text_domain">
 				<element value="my-textdomain"/>
 				<element value="library-textdomain"/>
 			</property>
@@ -88,7 +84,7 @@
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
-			<property name="prefixes" type="array">
+			<property name="prefixes">
 				<element value="my_prefix"/>
 			</property>
 		</properties>

--- a/wordpress.xml
+++ b/wordpress.xml
@@ -7,14 +7,13 @@
 	<exclude-pattern>/vendor/*</exclude-pattern>
 
 	<!-- Exclude the Node Modules directory. -->
-	<exclude-pattern>/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
 
 	<!-- Exclude minified Javascript files. -->
 	<exclude-pattern>*.js</exclude-pattern>
 	<exclude-pattern>*.min.js</exclude-pattern>
 	<exclude-pattern>*/build/*</exclude-pattern>
 	<exclude-pattern>*/dist/*</exclude-pattern>
-	<exclude-pattern>*Scripts.php</exclude-pattern>
 	<exclude-pattern>/coverage/*</exclude-pattern>
 	<exclude-pattern>/tests/_*</exclude-pattern>
 

--- a/wordpress.xml
+++ b/wordpress.xml
@@ -44,9 +44,10 @@
 	<!-- Let's also check that everything is properly documented. -->
 	<rule ref="WordPress-Docs"/>
 
-	<!-- Add in some extra rules from other standards. -->
+	<!-- Ignore Tab/Space indenting-->
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" ><severity>0</severity></rule>
 	<rule ref="Generic.WhiteSpace.DisallowTabIndent"><type>warning</type><severity>0</severity></rule>
+	<!-- Add in some extra rules from other standards. -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
 	<rule ref="Generic.Commenting.Todo"/>
 	<rule ref="Universal.Arrays.DisallowShortArraySyntax.Found" ><severity>0</severity></rule>


### PR DESCRIPTION
This pull request updates coding standards configuration for the project and makes a minor dependency update. The main changes involve improving and clarifying the PHP_CodeSniffer configuration files, particularly around whitespace rules and the formatting of properties, as well as updating the required version of a WordPress utility package.

**Coding standards configuration improvements:**

* Added explicit rules to ignore tab/space indenting warnings in both `.phpcs.xml.dist` and `wordpress.xml` by setting the severity of `Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed` and `Generic.WhiteSpace.DisallowTabIndent` to 0. [[1]](diffhunk://#diff-5fdfa058c1c76c029a34df51111b4505b2846c80adc27a8088b597fca41bc0a7R30-R46) [[2]](diffhunk://#diff-18c2cda21d4f61d81eb5c28bff905fdb6b3829f565c8b63b84053ac70900b0dbR47-L55)
* Updated the format of the `prefixes` and `text_domain` properties in both `.phpcs.xml.dist` and `wordpress.xml` to use `<element>` values instead of the previous array format, improving clarity and compatibility. [[1]](diffhunk://#diff-5fdfa058c1c76c029a34df51111b4505b2846c80adc27a8088b597fca41bc0a7R30-R46) [[2]](diffhunk://#diff-18c2cda21d4f61d81eb5c28bff905fdb6b3829f565c8b63b84053ac70900b0dbL67-R79) [[3]](diffhunk://#diff-18c2cda21d4f61d81eb5c28bff905fdb6b3829f565c8b63b84053ac70900b0dbL91-R88)
* Refined file exclusion patterns in `wordpress.xml` for better control over which files are checked, including adjusting patterns for JS, build, dist, coverage, and test files.
* Minor reordering and deduplication of rules in `wordpress.xml` for improved readability and maintainability. [[1]](diffhunk://#diff-18c2cda21d4f61d81eb5c28bff905fdb6b3829f565c8b63b84053ac70900b0dbR47-L55) [[2]](diffhunk://#diff-18c2cda21d4f61d81eb5c28bff905fdb6b3829f565c8b63b84053ac70900b0dbL67-R79)

**Dependency update:**

* Updated the required version of `bcgov/wordpress-utils` from `2.8.0` to `2.8.1` in both `composer.json` and the documentation (`README.md`).

**Script improvements:**

* Fixed a duplicated `--config-set` flag in the `phpcs` script and removed unnecessary output redirection for cleaner script execution in `composer.json`.